### PR TITLE
Cross-platform compatibility for PowerShell-OpenAI-Image-Generation

### DIFF
--- a/Open-AI-Requests/Create-OpenAI-API-ImageRequest.ps1
+++ b/Open-AI-Requests/Create-OpenAI-API-ImageRequest.ps1
@@ -6,7 +6,7 @@ if ($null -eq $openai_api_key) {
 $openai_api_key = ($openai_key_cred).Password | ConvertFrom-securestring -asplaintext
 
 $prompt_oai = @"
-try combining the ubiquitious powershell >_ logo and the OpenAI logo. Should include a terminal motif and an image in the terminal 
+Make a cool logo for the PowerShell language and terminal type. Make this logo fresh and have it include a terminal as well as the pwsh 7 and later >_ iconography. I love powershell!
 "@
 
 $openai_auth_headers = @{
@@ -39,6 +39,6 @@ $image_request_json_content_object = $image_request.Content | ConvertFrom-Json
 
 $destination = ("./OpenAI-Generations/" + "image-"+(Get-Date -Format 'yyyy-MM-dd')+ "-" + (Get-Random -count 1 -Maximum 1000) + ".png")
 
-Start-BitsTransfer -destination $destination -Source $image_request_json_content_object.data.url
+Invoke-WebRequest -URI $image_request_json_content_object.data.url -Method "GET" -outfile $destination
 write-output "============"
 write-output $image_request.Content

--- a/Readme.md
+++ b/Readme.md
@@ -7,6 +7,6 @@ This script is a candidate to turn into a module. This will likely take the form
 
 ---
 
-##BITS Transfer
+##IWR Vs. Start-BITSTransfer
+Invoke-WebRequest has replaced Start-BITSTransfer for cross-platform compatibility.
 
-This script makes use of the BITSTransfer tool, as such this requires a user session. When trying to use the BITS Transfer for an account without an active user session, the download will fail. This can be replaced with other commands to perform web requests.


### PR DESCRIPTION
There is an issue using Start-BITSTransfer on linux systems running powershell as that is not included in pwsh 7.4. There are many such cases of this. This fork proposes using Invoke-WebRequest in place of Start-BitsTransfer to provide cross-platform functionality. 

Prompt changes are incidental due to testing however, leaving them in. This should prob be updated to different logic like asking for user input but that is outside of the scope of this fork.